### PR TITLE
1.1 Changes

### DIFF
--- a/src/main/java/com/FileValidator/concrete/FileValidatorFactory.java
+++ b/src/main/java/com/FileValidator/concrete/FileValidatorFactory.java
@@ -1,0 +1,82 @@
+package com.FileValidator.concrete;
+
+import com.FileValidator.exceptions.InvalidFileException;
+import com.FileValidator.interfaces.FileValidator;
+import com.FileValidator.util.StringUtil;
+
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Optional;
+
+public class FileValidatorFactory {
+
+    private static final String FILE_VALIDATOR_SUFFIX = "FileValidator";
+
+    private static final String FILE_VALIDATOR_PACKAGE = "com.FileValidator.concrete.";
+
+    /***
+     * Call this function first. Then call validate to start file validation process.
+     * @param source file to be validated. You only need to provide the File object with its full file path
+     * @return returns corresponding FileValidator for the file type provided by the source file.
+     * @throws InvalidFileException
+     * @throws InstantiationException
+     */
+    public static FileValidator of(File source) throws InvalidFileException, InstantiationException {
+        return of(source, null, null);
+    }
+
+    public static FileValidator of(File source, String validatorPackagePrefix, String validatorClassSuffix) throws InvalidFileException, InstantiationException {
+        return getExtensionAndValidator(source, validatorPackagePrefix, validatorClassSuffix);
+    }
+
+    private static FileValidator getExtensionAndValidator(File source, String validatorPackagePrefix, String validatorClassSuffix) throws InvalidFileException, InstantiationException {
+        String filename = source.getName();
+
+        String extension = Optional.of(filename)
+                .filter(f -> f.contains("."))
+                .map(f -> f.substring(filename.lastIndexOf(".") + 1))
+                .orElse("");
+
+        if (StringUtil.isNullOrEmpty(extension)) {
+            throw new InvalidFileException("Invalid File type");
+        }
+
+        FileValidator fv = getValidator(extension.toUpperCase(), source, validatorPackagePrefix, validatorClassSuffix);
+        if (fv == null) {
+            throw new InstantiationException("Failed to initializing FileValidator");
+        }
+
+        return fv;
+    }
+
+    private static FileValidator getValidator(String classPrefix, File source, String validatorPackagePrefix, String validatorClassSuffix) {
+        try {
+            if (StringUtil.isNullOrEmpty(validatorPackagePrefix)) {
+                validatorPackagePrefix = FILE_VALIDATOR_PACKAGE;
+            }
+
+            if (StringUtil.isNullOrEmpty(validatorClassSuffix)) {
+                validatorClassSuffix = FILE_VALIDATOR_SUFFIX;
+            }
+
+            Class clazz = Class.forName(FILE_VALIDATOR_PACKAGE + classPrefix + FILE_VALIDATOR_SUFFIX);
+
+            Class[] parameterTypes = new Class[1];
+            parameterTypes[0] = File.class;
+
+            return (FileValidator) clazz.getDeclaredConstructor(parameterTypes).newInstance(source);
+        } catch(ClassNotFoundException e) {
+            e.printStackTrace();
+        } catch(InstantiationException  e) {
+            e.printStackTrace();
+        } catch(IllegalAccessException e) {
+            e.printStackTrace();
+        } catch (InvocationTargetException e) {
+            e.printStackTrace();
+        } catch (NoSuchMethodException e) {
+            e.printStackTrace();
+        }
+
+        return null;
+    }
+}

--- a/src/test/java/com/FileValidator/concrete/FunctionalityTest.java
+++ b/src/test/java/com/FileValidator/concrete/FunctionalityTest.java
@@ -1,25 +1,22 @@
 package com.FileValidator.concrete;
 
 import com.FileValidator.exceptions.InvalidFileException;
-import com.FileValidator.interfaces.FileValidator;
 import org.junit.Test;
 
 import java.io.File;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 public class FunctionalityTest {
 
     @Test
     public void testJpgFunctionality() throws Exception, InvalidFileException{
-        boolean validationResult = FileValidatorDelegator.of(
+        boolean validationResult = FileValidatorFactory.of(
                 new File("src\\test\\test-data\\xxx.jpg")).validate();
         System.out.println(validationResult);
     }
 
     @Test
     public void testPdfFunctionality() throws Exception, InvalidFileException {
-        boolean validationResult = FileValidatorDelegator.of(
+        boolean validationResult = FileValidatorFactory.of(
                 new File("src\\test\\test-data\\xxxx.pdf")).validate();
         System.out.println(validationResult);
     }


### PR DESCRIPTION
1.1 Changelog:
- Change `FileValidatorDelegator` to  `FileValidatorFactory`
- Added new optional parameters `validatorPackagePrefix` and `validatorClassSuffix` to the static factory method `of()`
- You are no longer limited to create a `FileValidator` under the same package as other default validator classes. You can still do so if you wish to but you can now specify the fully qualified package name and class suffix name. However, if you don't specify them, the factory method will automatically populate those parameters with default values
```Java
package com.someOtherPackage.PNGCustomValidator // You no longer need to conform to the naming scheme as mentioned in the usage section of readme.md

public class PNGCustomValidator implements FileValidator {
    // To-dos
}
```